### PR TITLE
Fix cluster argument to use cl variable

### DIFF
--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -90,7 +90,7 @@ module Wrapbox
         begin
           begin
             task = client
-              .run_task(build_run_task_options(class_name, method_name, args, command, environments, cluster, task_definition_arn, task_role_arn))
+              .run_task(build_run_task_options(class_name, method_name, args, command, environments, cl, task_definition_arn, task_role_arn))
               .tasks[0]
             raise LaunchFailure unless task
             @logger.debug("Create Task: #{task.task_arn}")


### PR DESCRIPTION
`client.run_task` で利用するcluster引数を `cl` に統一しました。