### PR TITLE
Print container stopped reason

### DIFF
--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -111,7 +111,7 @@ module Wrapbox
           task_status = fetch_task_status(cl, task.task_arn)
 
           # If exit_code is nil, Container is force killed or ECS failed to launch Container by Irregular situation
-          error_message = "Container #{task_definition_name} is failed. task=#{task.task_arn}, exit_code=#{task_status[:exit_code]}, reason=#{task_status[:stopped_reason]}"
+          error_message = "Container #{task_definition_name} is failed. task=#{task.task_arn}, exit_code=#{task_status[:exit_code]}, task_stopped_reason=#{task_status[:stopped_reason]}, container_stopped_reason=#{task_status[:container_stopped_reason]}"
           raise ContainerAbnormalEnd, error_message unless task_status[:exit_code]
           raise ExecutionFailure, error_message unless task_status[:exit_code] == 0
 
@@ -237,7 +237,12 @@ module Wrapbox
       def fetch_task_status(cluster, task_arn)
         task = client.describe_tasks(cluster: cluster, tasks: [task_arn]).tasks[0]
         container = task.containers.find { |c| c.name = task_definition_name }
-        {last_status: task.last_status, exit_code: container.exit_code, stopped_reason: task.stopped_reason}
+        {
+          last_status: task.last_status,
+          exit_code: container.exit_code,
+          stopped_reason: task.stopped_reason,
+          container_stopped_reason: container.reason
+        }
       end
 
       def register_task_definition(container_definition_overrides)


### PR DESCRIPTION
## WHAT

Just print contaier stopped reason.

## WHY

When caused some error (e.g. ExecutionFailure), that use task stopped reason for printing error message but it's just useless for developers, we should know about inner situation like below:

* current output in master branch:

```
master* $ wrapbox ecs run_cmd 'dd if=/dev/zero of=tempfile bs=1G count=6' -f config.yml --launch_retry=1
D, [2017-05-01T12:25:10.036054 #98966] DEBUG -- : Create Task: arn:aws:ecs:ap-northeast-1:287195237987:task/3bc6d4b0-dd2e-4df5-9a93-e166383cbd11
D, [2017-05-01T12:25:15.119290 #98966] DEBUG -- : Launch Task: arn:aws:ecs:ap-northeast-1:287195237987:task/3bc6d4b0-dd2e-4df5-9a93-e166383cbd11
D, [2017-05-01T12:25:15.136324 #98966] DEBUG -- : Stop Task: arn:aws:ecs:ap-northeast-1:287195237987:task/3bc6d4b0-dd2e-4df5-9a93-e166383cbd11
/Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:116:in `run_task': Container wrapbox_default is failed. task=arn:aws:ecs:ap-northeast-1:287195237987:task/3bc6d4b0-dd2e-4df5-9a93-e166383cbd11, exit_code=137, reason=Essential container in task exited (Wrapbox::Runner::Ecs::ExecutionFailure)
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:83:in `block (2 levels) in run_cmd'
```

* after improvement: 
```
master* $ wrapbox ecs run_cmd 'dd if=/dev/zero of=tempfile bs=1G count=6' -f config.yml --launch_retry=1
D, [2017-05-01T12:29:54.059912 #768] DEBUG -- : Create Task: arn:aws:ecs:ap-northeast-1:287195237987:task/3894c1a2-7e77-44a9-8271-73a030072b33
D, [2017-05-01T12:29:59.141858 #768] DEBUG -- : Launch Task: arn:aws:ecs:ap-northeast-1:287195237987:task/3894c1a2-7e77-44a9-8271-73a030072b33
D, [2017-05-01T12:29:59.161326 #768] DEBUG -- : Stop Task: arn:aws:ecs:ap-northeast-1:287195237987:task/3894c1a2-7e77-44a9-8271-73a030072b33
/Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:116:in `run_task': Container wrapbox_default is failed. task=arn:aws:ecs:ap-northeast-1:287195237987:task/3894c1a2-7e77-44a9-8271-73a030072b33, exit_code=137, task_stopped_reason=Essential container in task exited, container_stopped_reason=OutOfMemoryError: Container killed due to memory usage (Wrapbox::Runner::Ecs::ExecutionFailure)
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:83:in `block (2 levels) in run_cmd'
```

* diff:

```diff
- reason=Essential container in task exited (Wrapbox::Runner::Ecs::ExecutionFailure)
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:83:in `block (2 levels) in run_cmd'
+ task_stopped_reason=Essential container in task exited, container_stopped_reason=OutOfMemoryError: Container killed due to memory usage (Wrapbox::Runner::Ecs::ExecutionFailure)
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:83:in `block (2 levels) in run_cmd'
```