### PR TITLE
Print error details on LaunchFailure occured

### DIFF
--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -194,7 +194,10 @@ module Wrapbox
           end
         rescue LaunchFailure
           if launch_try_count >= parameter.launch_retry
-            raise
+            task_status = fetch_task_status(cl, task.task_arn)
+  
+            error_message = "Container #{task_definition_name} is failed. task=#{task.task_arn}, exit_code=#{task_status[:exit_code]}, task_stopped_reason=#{task_status[:stopped_reason]}, container_stopped_reason=#{task_status[:container_stopped_reason]}"
+            raise LaunchFailure, error_message
           else
             launch_try_count += 1
             @logger.debug("Retry Create Task after #{current_retry_interval} sec")


### PR DESCRIPTION
## WHAT 

Print error details when LaunchFailure occured.

This PR need to merge after https://github.com/reproio/wrapbox/pull/2.

## WHY

Some errors(e.g. LaunchFailure) print nothing. so just I want to know the details like below:

(command has no meaning, just I need to cause LaunchFailure)

* current output on master branch:

```
master* $ wrapbox ecs run_cmd 'cd /var && ls .' -f config.yml --launch_retry=1
D, [2017-05-01T15:02:01.018020 #8996] DEBUG -- : Create Task: arn:aws:ecs:ap-northeast-1:287195237987:task/c133dee9-904c-449d-8c44-1039fb693cab
D, [2017-05-01T15:02:06.099249 #8996] DEBUG -- : Retry Create Task after 1 sec
D, [2017-05-01T15:02:07.156958 #8996] DEBUG -- : Create Task: arn:aws:ecs:ap-northeast-1:287195237987:task/ce5135c9-0164-49d3-8a0b-31cc337e5f6e
/Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:178:in `rescue in create_task': Wrapbox::Runner::Ecs::LaunchFailure (Wrapbox::Runner::Ecs::LaunchFailure)
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:156:in `create_task'
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:100:in `run_task'
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:83:in `block (2 levels) in run_cmd'
```

* after improvement:

```
master* $ wrapbox ecs run_cmd 'cd /var && ls .' -f config.yml --launch_retry=1
D, [2017-05-01T15:01:23.103481 #8728] DEBUG -- : Create Task: arn:aws:ecs:ap-northeast-1:287195237987:task/6e248220-26c1-499c-81cf-805a3ca52c41
D, [2017-05-01T15:01:28.215686 #8728] DEBUG -- : Retry Create Task after 1 sec
D, [2017-05-01T15:01:29.280055 #8728] DEBUG -- : Create Task: arn:aws:ecs:ap-northeast-1:287195237987:task/5c3c3e94-c3d0-4e3e-b5c5-3a236327af05
/Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:200:in `rescue in create_task': Container wrapbox_default is failed. task=arn:aws:ecs:ap-northeast-1:287195237987:task/5c3c3e94-c3d0-4e3e-b5c5-3a236327af05, exit_code=, task_stopped_reason=Essential container in task exited, container_stopped_reason=CannotStartContainerError: API error (404): invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"exec: \\\"cd\\\": executable file not found in $PATH\"\n" (Wrapbox::Runner::Ecs::LaunchFailure)
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:144:in `create_task'
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:100:in `run_task'
	from /Users/reizist/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/wrapbox-0.3.0/lib/wrapbox/runner/ecs.rb:83:in `block (2 levels) in run_cmd'
```