### PR TITLE
Fix to fetch task status

### DIFF
--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -239,7 +239,7 @@ module Wrapbox
 
       def fetch_task_status(cluster, task_arn)
         task = client.describe_tasks(cluster: cluster, tasks: [task_arn]).tasks[0]
-        container = task.containers.find { |c| c.name = task_definition_name }
+        container = task.containers.find { |c| c.name == task_definition_name }
         {
           last_status: task.last_status,
           exit_code: container.exit_code,


### PR DESCRIPTION
`fetch_task_status` returns a container status that match `tash_definition_name`, not assignment.