### PR TITLE
Introduce WRAPBOX_CMD_INDEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Wrapbox.run_cmd(["ls ."], environments: [{name: "RAILS_ENV", value: "development
 | additional_container_definitions | Container definitions for sub containers                                                                    |
 | task_role_arn                    | see. http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html                         |
 
+`WRAPBOX_CMD_INDEX` environment variable is available in `run_cmd` and you can distinguish logs from each command like below:
+
+```
+log_configuration:
+  log_driver: syslog
+  options:
+    syslog-address: "tcp://192.168.0.42:123"
+    env: WRAPBOX_CMD_INDEX
+    tag: wrapbox-{{ printf "%03s" (.ExtraAttributes nil).WRAPBOX_CMD_INDEX }}
+```
+
 ### for docker
 | name                 | desc                                                        |
 | -------------------- | ----------------------------------------------------------- |

--- a/lib/wrapbox/runner/docker.rb
+++ b/lib/wrapbox/runner/docker.rb
@@ -35,9 +35,10 @@ module Wrapbox
 
         environments = extract_environments(environments)
 
-        ths = cmds.map do |cmd|
-          Thread.new(cmd) do |c|
-            exec_docker(definition: definition, cmd: c.split(/\s+/), environments: environments)
+        ths = cmds.map.with_index do |cmd, idx|
+          Thread.new(cmd, idx) do |c, i|
+            envs = environments + ["WRAPBOX_CMD_INDEX=#{idx}"]
+            exec_docker(definition: definition, cmd: c.split(/\s+/), environments: envs)
           end
         end
         ths.each(&:join)

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -76,14 +76,14 @@ module Wrapbox
 
       def run_cmd(cmds, container_definition_overrides: {}, **parameters)
         task_definition = register_task_definition(container_definition_overrides)
-        parameter = Parameter.new(**parameters)
 
-        ths = cmds.map do |cmd|
-          Thread.new(cmd) do |c|
+        ths = cmds.map.with_index do |cmd, idx|
+          Thread.new(cmd, idx) do |c, i|
+            envs = (parameters[:environments] || []) + [{name: "WRAPBOX_CMD_INDEX", value: i.to_s}]
             run_task(
               task_definition.task_definition_arn, nil, nil, nil,
               c.split(/\s+/),
-              parameter
+              Parameter.new(**parameters.merge(environments: envs))
             )
           end
         end

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -79,6 +79,7 @@ module Wrapbox
 
         ths = cmds.map.with_index do |cmd, idx|
           Thread.new(cmd, idx) do |c, i|
+            Thread.current[:cmd_index] = i
             envs = (parameters[:environments] || []) + [{name: "WRAPBOX_CMD_INDEX", value: i.to_s}]
             run_task(
               task_definition.task_definition_arn, nil, nil, nil,
@@ -111,7 +112,7 @@ module Wrapbox
           task_status = fetch_task_status(cl, task.task_arn)
 
           # If exit_code is nil, Container is force killed or ECS failed to launch Container by Irregular situation
-          error_message = "Container #{task_definition_name} is failed. task=#{task.task_arn}, exit_code=#{task_status[:exit_code]}, task_stopped_reason=#{task_status[:stopped_reason]}, container_stopped_reason=#{task_status[:container_stopped_reason]}"
+          error_message = build_error_message(task_definition_name, task.task_arn, task_status)
           raise ContainerAbnormalEnd, error_message unless task_status[:exit_code]
           raise ExecutionFailure, error_message unless task_status[:exit_code] == 0
 
@@ -195,9 +196,7 @@ module Wrapbox
         rescue LaunchFailure
           if launch_try_count >= parameter.launch_retry
             task_status = fetch_task_status(cl, task.task_arn)
-  
-            error_message = "Container #{task_definition_name} is failed. task=#{task.task_arn}, exit_code=#{task_status[:exit_code]}, task_stopped_reason=#{task_status[:stopped_reason]}, container_stopped_reason=#{task_status[:container_stopped_reason]}"
-            raise LaunchFailure, error_message
+            raise LaunchFailure, build_error_message(task_definition_name, task.task_arn, task_status)
           else
             launch_try_count += 1
             @logger.debug("Retry Create Task after #{current_retry_interval} sec")
@@ -343,6 +342,13 @@ module Wrapbox
           overrides: overrides,
           started_by: "wrapbox-#{Wrapbox::VERSION}",
         }
+      end
+
+      def build_error_message(task_definition_name, task_arn, task_status)
+        error_message = "Container #{task_definition_name} is failed. task=#{task_arn}, "
+        error_message << "cmd_index=#{Thread.current[:cmd_index]}, " if Thread.current[:cmd_index]
+        error_message << "exit_code=#{task_status[:exit_code]}, task_stopped_reason=#{task_status[:stopped_reason]}, container_stopped_reason=#{task_status[:container_stopped_reason]}"
+        error_message
       end
 
       class Cli < Thor


### PR DESCRIPTION
I've introduce `WRAPBOX_CMD_INDEX` environment variable.
It is useful for distinguishing logs from each command as I describe in READM.md.
