### PR TITLE
Fix "undefined local variable" error

### DIFF
--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -229,7 +229,7 @@ module Wrapbox
         end
       rescue Aws::Waiters::Errors::TooManyAttemptsError
         client.stop_task({
-          cluster: cl,
+          cluster: cluster,
           task: task_arn,
           reason: "process timeout",
         })


### PR DESCRIPTION
This PR will fix errors like below:

```
wrapbox-1553b56b1c94/lib/wrapbox/runner/ecs.rb:232:in `rescue in wait_task_stopped': undefined local variable or method `cl' for #<Wrapbox::Runner::Ecs:0x00000002d99700> (NameError)
	from /home/circleci/repro/vendor/bundle/ruby/2.4.0/bundler/gems/wrapbox-1553b56b1c94/lib/wrapbox/runner/ecs.rb:222:in `wait_task_stopped'
	from /home/circleci/repro/vendor/bundle/ruby/2.4.0/bundler/gems/wrapbox-1553b56b1c94/lib/wrapbox/runner/ecs.rb:105:in `run_task'
	from /home/circleci/repro/vendor/bundle/ruby/2.4.0/bundler/gems/wrapbox-1553b56b1c94/lib/wrapbox/runner/ecs.rb:84:in `block (2 levels) in run_cmd'
```