### PR TITLE
Fix stop_task when TooManyAttemptsError

### DIFF
--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -230,7 +230,7 @@ module Wrapbox
         end
       rescue Aws::Waiters::Errors::TooManyAttemptsError
         client.stop_task({
-          cluster: cl,
+          cluster: cluster,
           task: task_arn,
           reason: "process timeout",
         })


### PR DESCRIPTION
```
bundler: failed to load command: wrapbox (/opt/ruby/lib/ruby/gems/2.4.0/bin/wrapbox)
NameError: undefined local variable or method `cl' for #<Wrapbox::Runner::Ecs:0x005647a250a1c8>
/opt/ruby/lib/ruby/gems/2.4.0/bundler/gems/wrapbox-9df39be588af/lib/wrapbox/runner/ecs.rb:230:in `rescue in wait_task_stopped'
/opt/ruby/lib/ruby/gems/2.4.0/bundler/gems/wrapbox-9df39be588af/lib/wrapbox/runner/ecs.rb:220:in `wait_task_stopped'
/opt/ruby/lib/ruby/gems/2.4.0/bundler/gems/wrapbox-9df39be588af/lib/wrapbox/runner/ecs.rb:104:in `run_task'
/opt/ruby/lib/ruby/gems/2.4.0/bundler/gems/wrapbox-9df39be588af/lib/wrapbox/runner/ecs.rb:83:in `block (2 levels) in run_cmd'
```
