### PR TITLE
Support ECS new features and refactor configuration

### DIFF
--- a/wrapbox.gemspec
+++ b/wrapbox.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk", "~> 2.4"
+  spec.add_runtime_dependency "aws-sdk", "~> 2.10", ">= 2.10.109"
   spec.add_runtime_dependency "activesupport", ">= 4"
   spec.add_runtime_dependency "docker-api"
   spec.add_runtime_dependency "multi_json"


### PR DESCRIPTION
- deprecate `additional_container_definitions`, Use `container_definitions`
  - Use first of `container_definitions` as main container
- Support new ECS parameters
  - volumes
  - placement_constraints
  - placement_strategies
  - task level cpu, memory constraints
  - network_mode, network_configuration
  - requires_compatibilities, launch_type