### PR TITLE
Fix NoMethodError on #stop before #run

### DIFF
--- a/lib/wrapbox/log_fetcher/papertrail.rb
+++ b/lib/wrapbox/log_fetcher/papertrail.rb
@@ -24,7 +24,7 @@ module Wrapbox
 
       def stop
         @stop = true
-        @loop_thread.join(STOP_WAIT_TIMELIMIT)
+        @loop_thread&.join(STOP_WAIT_TIMELIMIT)
       end
 
       def main_loop


### PR DESCRIPTION
I fixed to raise NoMethodError when failed on `Wrapbox::Runner::Ecs#create_task`.

https://github.com/reproio/wrapbox/blob/15d46b0085180e42f11e6e697a2e38eab5ab95a5/lib/wrapbox/runner/ecs.rb#L160-L161