### PR TITLE
Support SIGNAL handling for ECS Task stopping

### DIFF
--- a/lib/wrapbox/log_fetcher/papertrail.rb
+++ b/lib/wrapbox/log_fetcher/papertrail.rb
@@ -24,7 +24,7 @@ module Wrapbox
 
       def stop
         @stop = true
-        @loop_thread.join(STOP_WAIT_TIMELIMIT)
+        @loop_thread&.join(STOP_WAIT_TIMELIMIT)
       end
 
       def main_loop

--- a/lib/wrapbox/runner/docker.rb
+++ b/lib/wrapbox/runner/docker.rb
@@ -60,7 +60,7 @@ module Wrapbox
 
         true
       rescue SignalException => e
-        sig = e.is_a?(Interrupt) ? "SIGINT" : e.signm
+        sig = "SIG#{Signal.signame(e.signo)}"
         if ignore_signal
           @logger.info("Receive #{sig} signal. But Docker container continue running")
         else
@@ -112,7 +112,7 @@ module Wrapbox
           raise ExecutionError, "exit_code=#{resp["StatusCode"]}"
         end
       rescue SignalException => e
-        sig = e.is_a?(Interrupt) ? "SIGINT" : e.signm
+        sig = Signal.signame(e.signo)
         container&.kill(signal: sig)
       ensure
         container.remove(force: true) if container && !keep_container

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -146,7 +146,7 @@ module Wrapbox
             )
           end
         end
-        ths.each { |th| th&.join }
+        ths.each(&:join)
 
         true
       rescue SignalException => e

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -159,8 +159,11 @@ module Wrapbox
             th.report_on_exception = false
             th.raise(e)
           end
-          thread_timeout_buffer = 15
-          ths.each { |th| th.join(TERM_TIMEOUT + thread_timeout_buffer) }
+          wait_until = Time.now + TERM_TIMEOUT + 15 # thread_timeout_buffer
+          ths.each do |th|
+            wait = wait_until - Time.now
+            th.join(wait) if wait.positive?
+          end
         end
         nil
       end

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -22,6 +22,7 @@ module Wrapbox
 
       EXECUTION_RETRY_INTERVAL = 3
       WAIT_DELAY = 5
+      TERM_TIMEOUT = 120
       HOST_TERMINATED_REASON_REGEXP = /Host EC2.*terminated/
 
       attr_reader \
@@ -128,12 +129,14 @@ module Wrapbox
         )
       end
 
-      def run_cmd(cmds, container_definition_overrides: {}, **parameters)
+      def run_cmd(cmds, container_definition_overrides: {}, ignore_signal: false, **parameters)
+        ths = []
+
         task_definition = prepare_task_definition(container_definition_overrides)
 
         cmds << nil if cmds.empty?
-        ths = cmds.map.with_index do |cmd, idx|
-          Thread.new(cmd, idx) do |c, i|
+        cmds.each_with_index do |cmd, idx|
+          ths << Thread.new(cmd, idx) do |c, i|
             Thread.current[:cmd_index] = i
             envs = (parameters[:environments] || []) + [{name: "WRAPBOX_CMD_INDEX", value: i.to_s}]
             run_task(
@@ -143,7 +146,23 @@ module Wrapbox
             )
           end
         end
-        ths.each(&:join)
+        ths.each { |th| th&.join }
+
+        true
+      rescue SignalException => e
+        sig = e.is_a?(Interrupt) ? "SIGINT" : e.signm
+        if ignore_signal
+          @logger.info("Receive #{sig} signal. But ECS Tasks continue running")
+        else
+          @logger.info("Receive #{sig} signal. Stop All tasks")
+          ths.each do |th|
+            th.report_on_exception = false
+            th.raise(e)
+          end
+          thread_timeout_buffer = 15
+          ths.each { |th| th.join(TERM_TIMEOUT + thread_timeout_buffer) }
+        end
+        nil
       end
 
       private
@@ -158,6 +177,8 @@ module Wrapbox
 
         begin
           task = create_task(task_definition_arn, class_name, method_name, args, command, parameter)
+          return unless task # only Task creation aborted by SignalException
+
           @log_fetcher.run if @log_fetcher
 
           @logger.debug("Launch Task: #{task.task_arn}")
@@ -188,6 +209,14 @@ module Wrapbox
             sleep EXECUTION_RETRY_INTERVAL
             retry
           end
+        rescue SignalException
+          client.stop_task(
+            cluster: cl,
+            task: task.task_arn,
+            reason: "signal interrupted"
+          )
+          wait_task_stopped(cl, task.task_arn, TERM_TIMEOUT)
+          @logger.debug("Stop Task: #{task.task_arn}")
         ensure
           if @log_fetcher
             begin
@@ -269,6 +298,17 @@ module Wrapbox
             sleep current_retry_interval
             current_retry_interval = [current_retry_interval * parameter.retry_interval_multiplier, parameter.max_retry_interval].min
             retry
+          end
+        rescue SignalException
+          if task
+            client.stop_task(
+              cluster: cl,
+              task: task.task_arn,
+              reason: "signal interrupted"
+            )
+            wait_task_stopped(cl, task.task_arn, TERM_TIMEOUT)
+            @logger.debug("Stop Task: #{task.task_arn}")
+            nil
           end
         end
       end
@@ -449,6 +489,7 @@ module Wrapbox
         method_option :launch_retry, type: :numeric
         method_option :execution_retry, type: :numeric
         method_option :max_retry_interval, type: :numeric
+        method_option :ignore_signal, type: :boolean, default: false, desc: "Even if receive a signal (like TERM, INT, QUIT), ECS Tasks continue running"
         def run_cmd(*args)
           repo = Wrapbox::ConfigRepository.new.tap { |r| r.load_yaml(options[:config]) }
           config = repo.get(options[:config_name])
@@ -464,14 +505,17 @@ module Wrapbox
             launch_timeout: options[:launch_timeout],
             launch_retry: options[:launch_retry],
             execution_retry: options[:execution_retry],
-            max_retry_interval: options[:max_retry_interval]
+            max_retry_interval: options[:max_retry_interval],
+            ignore_signal: options[:ignore_signal],
           }.reject { |_, v| v.nil? }
           if options[:cpu] || options[:memory]
             container_definition_overrides = {cpu: options[:cpu], memory: options[:memory]}.reject { |_, v| v.nil? }
           else
             container_definition_overrides = {}
           end
-          runner.run_cmd(args, environments: environments, container_definition_overrides: container_definition_overrides, **run_options)
+          unless runner.run_cmd(args, environments: environments, container_definition_overrides: container_definition_overrides, **run_options)
+            exit 1
+          end
         end
       end
     end

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -150,7 +150,7 @@ module Wrapbox
 
         true
       rescue SignalException => e
-        sig = e.is_a?(Interrupt) ? "SIGINT" : e.signm
+        sig = "SIG#{Signal.signame(e.signo)}"
         if ignore_signal
           @logger.info("Receive #{sig} signal. But ECS Tasks continue running")
         else

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -1,5 +1,5 @@
 default:
-  cluster: ecsr-test
+  cluster: <%= ENV["ECS_CLUSTER"] %>
   runner: ecs
   region: ap-northeast-1
   container_definition:

--- a/spec/wrapbox_spec.rb
+++ b/spec/wrapbox_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Wrapbox do
   it "can load yaml" do
     config = Wrapbox.configs[:default]
-    expect(config.cluster).to eq("ecsr-test")
+    expect(config.cluster).to eq(ENV["ECS_CLUSTER"])
     expect(config.region).to eq("ap-northeast-1")
     expect(config.container_definition[:cpu]).to be_a(Integer)
   end
@@ -23,6 +23,27 @@ describe Wrapbox do
       Wrapbox.run_cmd(["ls ."], environments: [{name: "RAILS_ENV", value: "development"}])
     end
 
+    specify "executable on ECS and kill task", aws: true do
+      r, w = IO.pipe
+      pid = fork do
+        puts "exec on child process"
+        r.close
+        unless Wrapbox.run_cmd(["ruby -e 'sleep 120'"], environments: [{name: "RAILS_ENV", value: "development"}])
+          w.write("ok")
+          w.flush
+        end
+      end
+
+      if pid
+        w.close
+        sleep 15
+        puts "send SIGTERM to child process"
+        Process.kill("SIGTERM", pid)
+        sleep 1
+        expect(r.read).to eq("ok")
+      end
+    end
+
     specify "executable on ECS with error", aws: true do
       expect {
         Wrapbox.run_cmd(["ls no_dir"], environments: [{name: "RAILS_ENV", value: "development"}])
@@ -37,6 +58,27 @@ describe Wrapbox do
 
     specify "executable on Docker" do
       Wrapbox.run_cmd(["ls ."], config_name: :docker, environments: [{name: "RAILS_ENV", value: "development"}])
+    end
+
+    specify "executable on Docker and kill task" do
+      r, w = IO.pipe
+      pid = fork do
+        puts "exec on child process"
+        r.close
+        unless Wrapbox.run_cmd(["sleep 30"], config_name: :docker, environments: [{name: "RAILS_ENV", value: "development"}])
+          w.write("ok")
+          w.flush
+        end
+      end
+
+      if pid
+        w.close
+        sleep 10
+        puts "send SIGTERM to child process"
+        Process.kill("SIGTERM", pid)
+        sleep 1
+        expect(r.read).to eq("ok")
+      end
     end
   end
 end


### PR DESCRIPTION
This patch support signal propagation to containers.

If user send signal to wrapbox command (TERM, INT, QUIT and so),
wrapbox propagates signal to ECS or docker.

To specify signal type on ECS is not supported. And so if use ECS, wrapbox kicks `stop_task` API.