### PR TITLE
Use modularized aws-sdk And Stop supporting aws-sdk-v2

### DIFF
--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -1,4 +1,5 @@
-require "aws-sdk"
+require "aws-sdk-ecs"
+require "aws-sdk-cloudwatch"
 require "multi_json"
 require "thor"
 require "yaml"

--- a/wrapbox.gemspec
+++ b/wrapbox.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk", ">= 2.10.109"
+  spec.add_runtime_dependency "aws-sdk-ecs", "~> 1"
+  spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1"
   spec.add_runtime_dependency "activesupport", ">= 4"
   spec.add_runtime_dependency "docker-api"
   spec.add_runtime_dependency "multi_json"


### PR DESCRIPTION
I want to avoid installing unnecessary gems.
aws-sdk-v3 support modularized gems.

<details>
<summary>before</summary>

```
Fetching gem metadata from https://rubygems.org/....................
Resolving dependencies........
Using concurrent-ruby 1.0.5
Using minitest 5.11.3
Using thread_safe 0.3.6
Using aws-partitions 1.63.0
Using aws-sigv4 1.0.2
Using jmespath 1.3.1
Using aws-sigv2 1.0.1
Using bundler 1.16.0
Using excon 0.60.0
Using i18n 0.9.5
Using tzinfo 1.2.5
Using aws-sdk-core 3.15.0
Using multi_json 1.13.1
Using thor 0.20.0
Using activesupport 5.1.5
Using aws-sdk-acm 1.3.0
Using aws-sdk-alexaforbusiness 1.1.0
Using aws-sdk-apigateway 1.9.0
Using aws-sdk-applicationautoscaling 1.7.0
Using aws-sdk-applicationdiscoveryservice 1.1.0
Using aws-sdk-appstream 1.5.0
Using aws-sdk-appsync 1.1.0
Using aws-sdk-athena 1.0.1
Using aws-sdk-autoscaling 1.4.0
Using aws-sdk-autoscalingplans 1.1.0
Using aws-sdk-batch 1.3.0
Using aws-sdk-budgets 1.5.0
Using aws-sdk-cloud9 1.1.0
Using aws-sdk-clouddirectory 1.1.0
Using aws-sdk-cloudformation 1.3.0
Using aws-sdk-cloudfront 1.1.0
Using aws-sdk-cloudhsm 1.3.0
Using aws-sdk-cloudhsmv2 1.1.0
Using aws-sdk-cloudsearch 1.0.1
Using aws-sdk-cloudsearchdomain 1.0.1
Using aws-sdk-cloudtrail 1.0.1
Using aws-sdk-cloudwatch 1.4.0
Using aws-sdk-cloudwatchevents 1.1.0
Using aws-sdk-cloudwatchlogs 1.2.0
Using aws-sdk-codebuild 1.6.0
Using aws-sdk-codecommit 1.2.0
Using aws-sdk-codedeploy 1.3.0
Using aws-sdk-codepipeline 1.1.0
Using aws-sdk-codestar 1.1.0
Using aws-sdk-cognitoidentity 1.0.1
Using aws-sdk-cognitoidentityprovider 1.3.0
Using aws-sdk-cognitosync 1.0.1
Using aws-sdk-comprehend 1.0.0
Using aws-sdk-configservice 1.5.0
Using aws-sdk-costandusagereportservice 1.0.1
Using aws-sdk-costexplorer 1.0.0
Using aws-sdk-databasemigrationservice 1.4.0
Using aws-sdk-datapipeline 1.0.1
Using aws-sdk-dax 1.0.1
Using aws-sdk-devicefarm 1.3.0
Using aws-sdk-directconnect 1.1.0
Using aws-sdk-directoryservice 1.1.0
Using aws-sdk-dynamodb 1.4.0
Using aws-sdk-dynamodbstreams 1.0.1
Using aws-sdk-ec2 1.27.0
Using aws-sdk-ecr 1.2.0
Using aws-sdk-ecs 1.8.0
Using aws-sdk-efs 1.0.1
Using aws-sdk-elasticache 1.3.0
Using aws-sdk-elasticbeanstalk 1.3.0
Using aws-sdk-elasticloadbalancing 1.2.0
Using aws-sdk-elasticloadbalancingv2 1.7.0
Using aws-sdk-elasticsearchservice 1.3.0
Using aws-sdk-elastictranscoder 1.0.1
Using aws-sdk-emr 1.1.0
Using aws-sdk-firehose 1.1.0
Using aws-sdk-gamelift 1.3.0
Using aws-sdk-glacier 1.6.0
Using aws-sdk-glue 1.5.0
Using aws-sdk-greengrass 1.2.0
Using aws-sdk-guardduty 1.2.0
Using aws-sdk-health 1.0.1
Using aws-sdk-iam 1.3.0
Using aws-sdk-importexport 1.0.1
Using aws-sdk-inspector 1.3.0
Using aws-sdk-iot 1.3.0
Using aws-sdk-iotdataplane 1.0.1
Using aws-sdk-kinesisanalytics 1.2.0
Using aws-sdk-kinesisvideo 1.0.0
Using aws-sdk-kinesisvideoarchivedmedia 1.0.0
Using aws-sdk-kinesisvideomedia 1.0.0
Using aws-sdk-kms 1.5.0
Using aws-sdk-lambda 1.4.0
Using aws-sdk-lambdapreview 1.0.1
Using aws-sdk-lex 1.3.0
Using aws-sdk-lexmodelbuildingservice 1.5.0
Using aws-sdk-lightsail 1.3.0
Using aws-sdk-machinelearning 1.0.1
Using aws-sdk-marketplacecommerceanalytics 1.0.1
Using aws-sdk-marketplaceentitlementservice 1.0.1
Using aws-sdk-marketplacemetering 1.0.1
Using aws-sdk-mediaconvert 1.1.0
Using aws-sdk-medialive 1.2.0
Using aws-sdk-mediapackage 1.0.0
Using aws-sdk-mediastore 1.1.0
Using aws-sdk-mediastoredata 1.1.0
Using aws-sdk-migrationhub 1.0.1
Using aws-sdk-iotjobsdataplane 1.0.0
Using aws-sdk-mq 1.0.0
Using aws-sdk-mturk 1.2.0
Using aws-sdk-opsworks 1.2.0
Using aws-sdk-opsworkscm 1.2.0
Using aws-sdk-organizations 1.7.0
Using aws-sdk-pinpoint 1.2.0
Using aws-sdk-polly 1.4.0
Using aws-sdk-pricing 1.0.0
Using aws-sdk-rds 1.13.0
Using aws-sdk-redshift 1.1.0
Using aws-sdk-rekognition 1.2.0
Using aws-sdk-resourcegroups 1.0.0
Using aws-sdk-resourcegroupstaggingapi 1.0.1
Using aws-sdk-route53 1.8.0
Using aws-sdk-route53domains 1.1.0
Using aws-sdk-sagemaker 1.5.0
Using aws-sdk-sagemakerruntime 1.0.0
Using aws-sdk-serverlessapplicationrepository 1.0.0
Using aws-sdk-servicecatalog 1.3.0
Using aws-sdk-servicediscovery 1.1.0
Using aws-sdk-ses 1.6.0
Using aws-sdk-shield 1.1.0
Using aws-sdk-simpledb 1.0.1
Using aws-sdk-sms 1.0.1
Using aws-sdk-snowball 1.2.0
Using aws-sdk-sns 1.1.0
Using aws-sdk-sqs 1.3.0
Using aws-sdk-ssm 1.7.0
Using aws-sdk-states 1.2.0
Using aws-sdk-storagegateway 1.2.0
Using aws-sdk-support 1.0.1
Using aws-sdk-swf 1.0.1
Using aws-sdk-transcribeservice 1.0.0
Using aws-sdk-translate 1.0.0
Using aws-sdk-waf 1.3.0
Using aws-sdk-wafregional 1.3.0
Using aws-sdk-workdocs 1.1.0
Using aws-sdk-workmail 1.0.0
Using aws-sdk-mobile 1.0.0
Using aws-sdk-kinesis 1.2.0
Using aws-sdk-workspaces 1.1.0
Using aws-sdk-xray 1.1.0
Using docker-api 1.34.0
Using aws-sdk-s3 1.8.1
Using aws-sdk-resources 3.12.0
Using aws-sdk 3.0.1
Using wrapbox 0.6.0
Bundler attempted to update wrapbox but its version stayed the same
Bundle updated!
```
</details>

<details>
<summary>after</summary>

```
Using rake 10.5.0
Using concurrent-ruby 1.0.5
Using i18n 0.9.5
Using minitest 5.11.3
Using thread_safe 0.3.6
Using tzinfo 1.2.5
Using activesupport 5.1.5
Using public_suffix 3.0.2
Using addressable 2.5.2
Using awesome_print 1.8.0
Using aws-partitions 1.63.0
Using aws-sigv4 1.0.2
Using jmespath 1.3.1
Using aws-sdk-core 3.15.0
Using aws-sdk-cloudwatch 1.4.0
Using aws-sdk-ecs 1.8.0
Using bundler 1.16.0
Using safe_yaml 1.0.4
Using crack 0.4.3
Using diff-lcs 1.3
Using excon 0.60.0
Using multi_json 1.13.1
Using docker-api 1.34.0
Using hashdiff 0.3.7
Using rspec-support 3.7.1
Using rspec-core 3.7.1
Using rspec-expectations 3.7.0
Using rspec-mocks 3.7.0
Using rspec 3.7.0
Using thor 0.20.0
Using tapp 1.5.1
Using tapp-awesome_print 1.0.1
Using webmock 3.3.0
Using wrapbox 0.6.0 from source at `.`
Bundle complete! 7 Gemfile dependencies, 34 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```
</details>