### PR TITLE
Support Fargate

### DIFF
--- a/lib/wrapbox/configuration.rb
+++ b/lib/wrapbox/configuration.rb
@@ -25,6 +25,7 @@ module Wrapbox
     :cpu,
     :memory,
     :task_role_arn,
+    :execution_role_arn,
     :keep_container,
     :log_fetcher
   ) do
@@ -52,6 +53,7 @@ module Wrapbox
         config["cpu"]&.to_s,
         config["memory"]&.to_s,
         config["task_role_arn"],
+        config["execution_role_arn"],
         config["keep_container"],
         config["log_fetcher"]&.deep_symbolize_keys
       )

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -43,7 +43,8 @@ module Wrapbox
         :network_configuration,
         :cpu,
         :memory,
-        :task_role_arn
+        :task_role_arn,
+        :execution_role_arn
 
       def initialize(options)
         @name = options[:name]
@@ -90,6 +91,7 @@ module Wrapbox
         end
 
         @task_role_arn = options[:task_role_arn]
+        @execution_role_arn = options[:execution_role_arn]
         $stdout.sync = true
         @logger = Logger.new($stdout)
         if options[:log_fetcher]
@@ -102,6 +104,7 @@ module Wrapbox
         attr_reader \
           :environments,
           :task_role_arn,
+          :execution_role_arn,
           :cluster,
           :timeout,
           :launch_timeout,
@@ -390,6 +393,8 @@ module Wrapbox
             container_definitions: overrided_container_definitions,
             volumes: volumes,
             requires_compatibilities: requires_compatibilities,
+            task_role_arn: task_role_arn,
+            execution_role_arn: execution_role_arn
           }).task_definition
         rescue Aws::ECS::Errors::ClientException
           raise if register_retry_count > 2


### PR DESCRIPTION
Fargate needs `execution_role_arn` on task_definition

Sample yml:

```
default:
  cluster: sample-cluster
  region: ap-northeast-1
  task_role_arn: 'arn:aws:iam::11111111111111:role/taskRole'
  execution_role_arn: 'arn:aws:iam::11111111111:role/ecsTaskExecutionRole'
  launch_type: 'FARGATE'
  requires_compatibilities: ['FARGATE']
  network_mode: 'awsvpc'
  network_configuration:
    awsvpc_configuration:
      subnets: ["subnet-xxxxxxxx"]
      security_groups: ["sg-xxxxxxxx"]
      assign_public_ip: 'ENABLED'
  cpu: 1024
  memory: 2048
  container_definitions:
	...
```