### PR TITLE
Support tagging ECS resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,20 +88,23 @@ Wrapbox.run_cmd(["ls ."], environments: [{name: "RAILS_ENV", value: "development
 
 ### for ECS
 
-| name                  | desc                                                                                                        |
-| --------------------  | ------------------------------------------------                                                            |
-| cluster               | target ECS cluster name                                                                                     |
-| region                | region of ECS cluster                                                                                       |
-| container_definitions | see. http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
-| task_role_arn         | see. http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html                         |
-| volumes               | see. http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
-| placement_constraints | see. http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
-| placement_strategy    | see. http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
-| launch_type           | see. http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method                 |
-| network_mode          | see. http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
-| network_configuration | see. http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method                 |
-| cpu    | see. http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
-| memory    | see. http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
+| name                    | desc                                                                                                       |
+| ----------------------- | ------------------------------------------------                                                           |
+| cluster                 | target ECS cluster name                                                                                    |
+| region                  | region of ECS cluster                                                                                      |
+| container_definitions   | see http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
+| task_role_arn           | see http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html                         |
+| volumes                 | see http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
+| placement_constraints   | see http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
+| placement_strategy      | see http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
+| launch_type             | see http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method                 |
+| network_mode            | see http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
+| network_configuration   | see http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method                 |
+| cpu                     | see http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
+| memory                  | see http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
+| enable_ecs_managed_tags | see https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method                |
+| tags                    | tags of task definitions. see also https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
+| propagate_tags          | specify `"TASK_DEFINITION"` if you want to propagate tags to tasks. see also https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method |
 
 `WRAPBOX_CMD_INDEX` environment variable is available in `run_cmd` and you can distinguish logs from each command like below:
 

--- a/lib/wrapbox/configuration.rb
+++ b/lib/wrapbox/configuration.rb
@@ -28,7 +28,10 @@ module Wrapbox
     :task_role_arn,
     :execution_role_arn,
     :keep_container,
-    :log_fetcher
+    :log_fetcher,
+    :tags,
+    :enable_ecs_managed_tags,
+    :propagate_tags,
   ) do
     def self.load_config(config)
       new(
@@ -57,7 +60,10 @@ module Wrapbox
         config["task_role_arn"],
         config["execution_role_arn"],
         config["keep_container"],
-        config["log_fetcher"]&.deep_symbolize_keys
+        config["log_fetcher"]&.deep_symbolize_keys,
+        config["tags"],
+        config["enable_ecs_managed_tags"],
+        config["propagate_tags"],
       )
     end
 

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -44,7 +44,10 @@ module Wrapbox
         :cpu,
         :memory,
         :task_role_arn,
-        :execution_role_arn
+        :execution_role_arn,
+        :enable_ecs_managed_tags,
+        :tags,
+        :propagate_tags
 
       def initialize(options)
         @name = options[:name]
@@ -61,6 +64,9 @@ module Wrapbox
         @network_configuration = options[:network_configuration]
         @cpu = options[:cpu]
         @memory = options[:memory]
+        @enable_ecs_managed_tags = options[:enable_ecs_managed_tags]
+        @tags = options[:tags]
+        @propagate_tags = options[:propagate_tags]
 
         @container_definitions = options[:container_definition] ? [options[:container_definition]] : options[:container_definitions] || []
         @container_definitions.concat(options[:additional_container_definitions]) if options[:additional_container_definitions] # deprecated
@@ -404,7 +410,8 @@ module Wrapbox
             volumes: volumes,
             requires_compatibilities: requires_compatibilities,
             task_role_arn: task_role_arn,
-            execution_role_arn: execution_role_arn
+            execution_role_arn: execution_role_arn,
+            tags: tags,
           }).task_definition
         rescue Aws::ECS::Errors::ClientException
           raise if register_retry_count > 2
@@ -490,6 +497,8 @@ module Wrapbox
           launch_type: launch_type,
           network_configuration: network_configuration,
           started_by: "wrapbox-#{Wrapbox::VERSION}",
+          enable_ecs_managed_tags: enable_ecs_managed_tags,
+          propagate_tags: propagate_tags,
         }
       end
 


### PR DESCRIPTION
This PR supports [tagging ECS resources](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html).
You can run tasks with tags using a configuration like below:

```yaml
default:
  cluster: default
  runner: ecs
  region: ap-northeast-1
  cpu: 256
  memory: 256
  tags:
    - key: Foo
      value: "1"
  enable_ecs_managed_tags: true
  propagate_tags: TASK_DEFINITION

  container_definitions:
    - image: ubuntu
      essential: true
```

I want this feature because we can restrict permissions using tags like below:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": "ecs:DescribeTasks",
            "Resource": "*",
            "Condition": {
                "StringEquals": {
                    "ecs:ResourceTag/Foo": "1"
                }
            }
        }
    ]
}
```