### PR TITLE
 Add a feature to launch a new instance per task like Fargate

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Wrapbox.run_cmd(["ls ."], environments: [{name: "RAILS_ENV", value: "development
 | enable_ecs_managed_tags | see https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method                |
 | tags                    | tags of task definitions. see also https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
 | propagate_tags          | specify `"TASK_DEFINITION"` if you want to propagate tags to tasks. see also https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method |
+| launch_instances        | specify `launch_template` and `instance_type` for [Aws::EC2::Client#run_instances](https://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#run_instances-instance_method). You can also specify `wait_until_instance_terminated` (default: true) |
 
 `WRAPBOX_CMD_INDEX` environment variable is available in `run_cmd` and you can distinguish logs from each command like below:
 

--- a/lib/wrapbox/configuration.rb
+++ b/lib/wrapbox/configuration.rb
@@ -32,6 +32,7 @@ module Wrapbox
     :tags,
     :enable_ecs_managed_tags,
     :propagate_tags,
+    :launch_instances,
   ) do
     def self.load_config(config)
       new(
@@ -64,6 +65,7 @@ module Wrapbox
         config["tags"],
         config["enable_ecs_managed_tags"],
         config["propagate_tags"],
+        config["launch_instances"]&.deep_symbolize_keys,
       )
     end
 

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -58,7 +58,7 @@ module Wrapbox
         @cluster = options[:cluster]
         @region = options[:region]
         @volumes = options[:volumes]
-        @placement_constraints = options[:placement_constraints]
+        @placement_constraints = options[:placement_constraints] || []
         @placement_strategy = options[:placement_strategy]
         @launch_type = options[:launch_type]
         @requires_compatibilities = options[:requires_compatibilities]
@@ -519,7 +519,7 @@ module Wrapbox
           task_definition: task_definition_arn,
           overrides: overrides,
           placement_strategy: placement_strategy,
-          placement_constraints: (placement_constraints || []) + additional_placement_constraints,
+          placement_constraints: placement_constraints + additional_placement_constraints,
           launch_type: launch_type,
           network_configuration: network_configuration,
           started_by: "wrapbox-#{Wrapbox::VERSION}",

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -6,6 +6,7 @@ require "yaml"
 require "active_support/core_ext/hash"
 require "pp"
 require "shellwords"
+require "thwait"
 
 require "wrapbox"
 require "wrapbox/config_repository"
@@ -172,6 +173,8 @@ module Wrapbox
             )
           end
         end
+        ThreadsWait.all_waits(ths)
+        # Raise an error if some threads have an error
         ths.each(&:join)
 
         true

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -10,6 +10,7 @@ require "shellwords"
 require "wrapbox"
 require "wrapbox/config_repository"
 require "wrapbox/log_fetcher"
+require "wrapbox/runner/ecs/instance_manager"
 require "wrapbox/version"
 
 module Wrapbox
@@ -67,6 +68,9 @@ module Wrapbox
         @enable_ecs_managed_tags = options[:enable_ecs_managed_tags]
         @tags = options[:tags]
         @propagate_tags = options[:propagate_tags]
+        if options[:launch_instances]
+          @instance_manager = Wrapbox::Runner::Ecs::InstanceManager.new(@cluster, @region, options[:launch_instances])
+        end
 
         @container_definitions = options[:container_definition] ? [options[:container_definition]] : options[:container_definitions] || []
         @container_definitions.concat(options[:additional_container_definitions]) if options[:additional_container_definitions] # deprecated
@@ -133,11 +137,17 @@ module Wrapbox
         task_definition = prepare_task_definition(container_definition_overrides)
         parameter = Parameter.new(**parameters)
 
+        if @instance_manager
+          Thread.new { @instance_manager.start_preparing_instances(1) }
+        end
+
         run_task(
           task_definition.task_definition_arn, class_name, method_name, args,
           ["bundle", "exec", "rake", "wrapbox:run"],
           parameter
         )
+      ensure
+        @instance_manager&.terminate_all_instances
       end
 
       def run_cmd(cmds, container_definition_overrides: {}, ignore_signal: false, **parameters)
@@ -146,6 +156,11 @@ module Wrapbox
         task_definition = prepare_task_definition(container_definition_overrides)
 
         cmds << nil if cmds.empty?
+
+        if @instance_manager
+          Thread.new { @instance_manager.start_preparing_instances(cmds.size) }
+        end
+
         cmds.each_with_index do |cmd, idx|
           ths << Thread.new(cmd, idx) do |c, i|
             Thread.current[:cmd_index] = i
@@ -177,6 +192,8 @@ module Wrapbox
           end
         end
         nil
+      ensure
+        @instance_manager&.terminate_all_instances
       end
 
       private
@@ -189,8 +206,9 @@ module Wrapbox
         cl = parameter.cluster || self.cluster
         execution_try_count = 0
 
+        ec2_instance_id = @instance_manager&.pop_ec2_instance_id
         begin
-          task = create_task(task_definition_arn, class_name, method_name, args, command, parameter)
+          task = create_task(task_definition_arn, class_name, method_name, args, command, parameter, ec2_instance_id)
           return unless task # only Task creation aborted by SignalException
 
           @logger.debug("Launch Task: #{task.task_arn}")
@@ -237,10 +255,11 @@ module Wrapbox
               @logger.warn(e)
             end
           end
+          @instance_manager.terminate_instance(ec2_instance_id) if ec2_instance_id
         end
       end
 
-      def create_task(task_definition_arn, class_name, method_name, args, command, parameter)
+      def create_task(task_definition_arn, class_name, method_name, args, command, parameter, ec2_instance_id)
         cl = parameter.cluster || self.cluster
         launch_type = parameter.launch_type || self.launch_type
         args = Array(args)
@@ -249,7 +268,7 @@ module Wrapbox
         current_retry_interval = parameter.retry_interval
 
         begin
-          run_task_options = build_run_task_options(task_definition_arn, class_name, method_name, args, command, cl, launch_type, parameter.environments, parameter.task_role_arn)
+          run_task_options = build_run_task_options(task_definition_arn, class_name, method_name, args, command, cl, launch_type, parameter.environments, parameter.task_role_arn, ec2_instance_id)
           @logger.debug("Task Options: #{run_task_options}")
 
           begin
@@ -455,7 +474,7 @@ module Wrapbox
         )
       end
 
-      def build_run_task_options(task_definition_arn, class_name, method_name, args, command, cluster, launch_type, environments, task_role_arn)
+      def build_run_task_options(task_definition_arn, class_name, method_name, args, command, cluster, launch_type, environments, task_role_arn, ec2_instance_id)
         env = environments
         env += [
           {
@@ -488,12 +507,16 @@ module Wrapbox
         role_arn = task_role_arn || self.task_role_arn
         overrides[:task_role_arn] = role_arn if role_arn
 
+        additional_placement_constraints = []
+        if ec2_instance_id
+          additional_placement_constraints << { type: "memberOf", expression: "ec2InstanceId == #{ec2_instance_id}" }
+        end
         {
           cluster: cluster || self.cluster,
           task_definition: task_definition_arn,
           overrides: overrides,
           placement_strategy: placement_strategy,
-          placement_constraints: placement_constraints,
+          placement_constraints: (placement_constraints || []) + additional_placement_constraints,
           launch_type: launch_type,
           network_configuration: network_configuration,
           started_by: "wrapbox-#{Wrapbox::VERSION}",

--- a/lib/wrapbox/runner/ecs/instance_manager.rb
+++ b/lib/wrapbox/runner/ecs/instance_manager.rb
@@ -1,0 +1,89 @@
+require "aws-sdk-ec2"
+require "aws-sdk-ecs"
+
+module Wrapbox
+  module Runner
+    class Ecs
+      class InstanceManager
+        def initialize(cluster, region, launch_template:, instance_type: nil, wait_until_instance_terminated: true)
+          @cluster = cluster
+          @region = region
+          @launch_template = launch_template
+          @instance_type = instance_type
+          @wait_until_instance_terminated = wait_until_instance_terminated
+          @queue = Queue.new
+          @instance_ids = []
+        end
+
+        def pop_ec2_instance_id
+          @queue.pop
+        end
+
+        def start_preparing_instances(count)
+          preparing_instance_ids = ec2_client.run_instances(
+            launch_template: @launch_template,
+            instance_type: @instance_type,
+            min_count: count,
+            max_count: count
+          ).instances.map(&:instance_id)
+          @instance_ids.concat(preparing_instance_ids)
+          ec2_client.wait_until(:instance_running, instance_ids: preparing_instance_ids)
+
+          waiter = Aws::Waiters::Waiter.new(
+            max_attempts: 40,
+            delay: 15,
+            poller: Aws::Waiters::Poller.new(
+              operation_name: :list_container_instances,
+              acceptors: [
+                {
+                  "expected" => true,
+                  "matcher" => "path",
+                  "state" => "success",
+                  "argument" => "length(container_instance_arns) > `0`"
+                }
+              ]
+            )
+          )
+
+          while preparing_instance_ids.size > 0
+            waiter.wait(client: ecs_client, params: { cluster: @cluster, filter: "ec2InstanceId in [#{preparing_instance_ids.join(",")}]" }).each do |resp|
+              ecs_client.describe_container_instances(cluster: @cluster, container_instances: resp.container_instance_arns).container_instances.each do |c|
+                preparing_instance_ids.delete(c.ec2_instance_id)
+                @queue << c.ec2_instance_id
+              end
+            end
+          end
+        end
+
+        def terminate_instance(instance_id)
+          ec2_client.terminate_instances(instance_ids: [instance_id])
+          if @wait_until_instance_terminated
+            ec2_client.wait_until(:instance_terminated, instance_ids: [instance_id])
+          end
+          @instance_ids.delete(instance_id)
+        end
+
+        def terminate_all_instances
+          # Duplicate @instance_ids because other threads can change it
+          remaining_instance_ids = @instance_ids.dup
+          return if remaining_instance_ids.empty?
+          ec2_client.terminate_instances(instance_ids: remaining_instance_ids)
+          if @wait_until_instance_terminated
+            ec2_client.wait_until(:instance_terminated, instance_ids: remaining_instance_ids)
+          end
+          @instance_ids.clear
+        end
+
+        private
+
+        def ecs_client
+          @ecs_client ||= Aws::ECS::Client.new({ region: @region }.reject { |_, v| v.nil? })
+        end
+
+        def ec2_client
+          @ec2_client ||= Aws::EC2::Client.new({ region: @region }.reject { |_, v| v.nil? })
+        end
+      end
+    end
+  end
+end

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -18,3 +18,18 @@ docker:
     image: joker1007/wrapbox
     cpu: 600
     memory: 1024
+
+ecs_with_launch_template:
+  cluster: <%= ENV["ECS_CLUSTER"] %>
+  runner: ecs
+  region: ap-northeast-1
+  container_definition:
+    image: joker1007/wrapbox
+    cpu: 256
+    memory: 256
+    essential: true
+  launch_instances:
+    launch_template:
+      launch_template_id: <%= ENV["LAUNCH_TEMPLATE_ID"] %>
+      version: $Latest
+    wait_until_instance_terminated: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ end
 
 RSpec.configure do |c|
   c.order = "random"
-  c.filter_run_excluding aws: true
+  c.filter_run_excluding aws: true unless ENV["RUN_AWS_SPECS"] == "true"
 end
 
 if defined?(Tapp)

--- a/spec/wrapbox_spec.rb
+++ b/spec/wrapbox_spec.rb
@@ -16,11 +16,19 @@ describe Wrapbox do
     specify "executable on Docker" do
       Wrapbox.run("TestJob", :perform, ["arg1", ["arg2", "arg3"]], config_name: :docker, environments: [{name: "RAILS_ENV", value: "development"}])
     end
+
+    specify "executable on ECS with launch template", aws: true do
+      Wrapbox.run("TestJob", :perform, ["arg1", ["arg2", "arg3"]], config_name: :ecs_with_launch_template, environments: [{name: "RAILS_ENV", value: "development"}])
+    end
   end
 
   describe ".run_cmd" do
     specify "executable on ECS", aws: true do
       Wrapbox.run_cmd(["ls ."], environments: [{name: "RAILS_ENV", value: "development"}])
+    end
+
+    specify "executable on ECS with launch template", aws: true do
+      Wrapbox.run_cmd(["ls ."], config_name: :ecs_with_launch_template, environments: [{name: "RAILS_ENV", value: "development"}])
     end
 
     specify "executable on ECS and kill task", aws: true do

--- a/wrapbox.gemspec
+++ b/wrapbox.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "aws-sdk-ec2", "~> 1"
   spec.add_runtime_dependency "aws-sdk-ecs", "~> 1"
   spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1"
   spec.add_runtime_dependency "activesupport", ">= 4"


### PR DESCRIPTION
It takes much time to launch Fargate tasks and the performance of Fargate is low, so this feature can be used as an alternative to Fargate.
