### PR TITLE
Reduce describe_tasks calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Wrapbox.run("TestJob", :perform, ["arg1", ["arg2", "arg3"]], config_name: :docke
 Wrapbox.run_cmd(["ls ."], environments: [{name: "RAILS_ENV", value: "development"}])
 ```
 
+If ECS runner cannot create task, it puts custom metric data to CloudWatch.
+Custom metric data is `wrapbox/WaitingTaskCount` that has `ClusterName` dimension.
+And, it retry launching until retry count reach `launch_retry`.
+
+After task exited, Wrapbox checks main container exit code.
+If exit code is not 0, Wrapbox raise error.
+
 ## Config
 
 ### Common
@@ -123,28 +130,55 @@ log_configuration:
 | --------------------  | ----------------------------------------------------------- |
 | container_definitions | only use `image`, `cpu`, `memory`, and `memory_reservation` |
 | keep_container        | If true, doesn't delete the container when the command ends |
-| use_sudo              | If true, invoke `sudo docker` command                       |
 
 ## API
 
-#### `run(class_name, method_name, args, container_definition_overrides: {}, environments: [], task_role_arn: nil, cluster: nil, timeout: 3600 * 24, launch_timeout: 60 * 10, launch_retry: 10, retry_interval: 1, retry_interval_multiplier: 2, max_retry_interval: 120, execution_retry: 0)`
+### `Wrapbox.run`
 
-#### `run_cmd(*cmd, container_definition_overrides: {}, environments: [], task_role_arn: nil, cluster: nil, timeout: 3600 * 24, launch_timeout: 60 * 10, launch_retry: 10, retry_interval: 1, retry_interval_multiplier: 2, max_retry_interval: 120, execution_retry: 0)`
+```ruby
+Wrapbox.run(class_name, method_name, args,
+  runner: nil, # The "runner" value is used in the configuration  if it is nil.
+  config_name: nil, # "default" configuration is used if it is nil.
+  cluster: nil, # Available only for ECS runner. The "cluster" value in the configuration is used if it is nil.
+  launch_type: "EC2", # Available only for ECS runner. The "launch_type" value in the configuration is used if it is nil.
+  task_role_arn: nil, # Available only for ECS runner. The "task_role_arn" value in the configuration is used if it is nil.
+  execution_role_arn: nil, # Available only for ECS runner. The "execution_role_arn" value in the configuration is used if it is nil.
+  container_definition_overrides: {},
+  environments: [],
+  timeout: 3600 * 24, # Available only for ECS runner. # Available only for ECS runner.
+  launch_timeout: 60 * 10, # Available only for ECS runner.
+  launch_retry: 10, # Available only for ECS runner.
+  retry_interval: 1, # Available only for ECS runner.
+  retry_interval_multiplier: 2, # Available only for ECS runner.
+  max_retry_interval: 120, # Available only for ECS runner.
+  execution_retry: 0, # Available only for ECS runner.
+  keep_container: nil, # Available only for Docker runner. The "keep_container" value in the configuration is used if it is nil.
+)
+```
 
-following options is only for ECS.
+### `Wrapbox.run_cmd`
 
-- task_role_arn
-- cluster
-- timeout
-- launch_timeout
-- launch_retry
-
-If Wrapbox cannot create task, it puts custom metric data to CloudWatch.
-Custom metric data is `wrapbox/WaitingTaskCount` that has `ClusterName` dimension.
-And, it retry launching until retry count reach `launch_retry`.
-
-After task exited, Wrapbox checks main container exit code.
-If exit code is not 0, Wrapbox raise error.
+```ruby
+Wrapbox.run_cmd(*cmd,
+  runner: nil, # The "runner" value is used in the configuration  if it is nil.
+  config_name: nil, # "default" configuration is used if it is nil.
+  cluster: nil, # Available only for ECS runner. The "cluster" value in the configuration is used if it is nil.
+  launch_type: "EC2", # Available only for ECS runner. The "launch_type" value in the configuration is used if it is nil.
+  task_role_arn: nil, # Available only for ECS runner. The "task_role_arn" value in the configuration is used if it is nil.
+  execution_role_arn: nil, # Available only for ECS runner. The "execution_role_arn" value in the configuration is used if it is nil.
+  container_definition_overrides: {},
+  ignore_signal: false,
+  environments: [],
+  timeout: 3600 * 24, # Available only for ECS runner. # Available only for ECS runner.
+  launch_timeout: 60 * 10, # Available only for ECS runner.
+  launch_retry: 10, # Available only for ECS runner.
+  retry_interval: 1, # Available only for ECS runner.
+  retry_interval_multiplier: 2, # Available only for ECS runner.
+  max_retry_interval: 120, # Available only for ECS runner.
+  execution_retry: 0, # Available only for ECS runner.
+  keep_container: nil, # Available only for Docker runner. The "keep_container" value in the configuration is used if it is nil.
+)
+```
 
 ## Development
 

--- a/lib/wrapbox/configuration.rb
+++ b/lib/wrapbox/configuration.rb
@@ -75,19 +75,23 @@ module Wrapbox
       super
     end
 
-    def build_runner(overrided_runner = nil)
+    def runner_class(overrided_runner = nil)
       r = overrided_runner || runner
       raise "#{r} is unsupported runner" unless AVAILABLE_RUNNERS.include?(r.to_sym)
       require "wrapbox/runner/#{r}"
-      Wrapbox::Runner.const_get(r.to_s.camelcase).new(to_h)
+      Wrapbox::Runner.const_get(r.to_s.camelcase)
     end
 
     def run(class_name, method_name, args, runner: nil, **options)
-      build_runner(runner).run(class_name, method_name, args, **options)
+      klass = runner_class(runner)
+      overridable_options, parameters = klass.split_overridable_options_and_parameters(options)
+      klass.new(to_h.merge(overridable_options)).run(class_name, method_name, args, **parameters)
     end
 
     def run_cmd(*cmd, runner: nil, **options)
-      build_runner(runner).run_cmd(*cmd, **options)
+      klass = runner_class(runner)
+      overridable_options, parameters = klass.split_overridable_options_and_parameters(options)
+      klass.new(to_h.merge(overridable_options)).run_cmd(*cmd, **parameters)
     end
   end
 end

--- a/lib/wrapbox/runner/docker.rb
+++ b/lib/wrapbox/runner/docker.rb
@@ -17,7 +17,14 @@ module Wrapbox
         :keep_container
 
       def self.split_overridable_options_and_parameters(options)
-        [{}, options]
+        opts = options.dup
+        overridable_options = {}
+        %i[keep_container].each do |key|
+          value = opts.delete(key)
+          overridable_options[key] = value if value
+        end
+
+        [overridable_options, opts]
       end
 
       def initialize(options)

--- a/lib/wrapbox/runner/docker.rb
+++ b/lib/wrapbox/runner/docker.rb
@@ -16,6 +16,10 @@ module Wrapbox
         :container_definition,
         :keep_container
 
+      def self.split_overridable_options_and_parameters(options)
+        [{}, options]
+      end
+
       def initialize(options)
         @name = options[:name]
         @container_definitions = options[:container_definition] ? [options[:container_definition]] : options[:container_definitions]

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -216,11 +216,11 @@ module Wrapbox
           task = create_task(task_definition_arn, class_name, method_name, args, command, parameter, ec2_instance_id)
           return unless task # only Task creation aborted by SignalException
 
-          @logger.debug("Launch Task: #{task.task_arn}")
+          @logger.info("Launch Task: #{task.task_arn}")
 
           wait_task_stopped(cl, task.task_arn, parameter.timeout)
 
-          @logger.debug("Stop Task: #{task.task_arn}")
+          @logger.info("Stop Task: #{task.task_arn}")
 
           # Avoid container exit code fetch miss
           sleep WAIT_DELAY

--- a/lib/wrapbox/runner/ecs/instance_manager.rb
+++ b/lib/wrapbox/runner/ecs/instance_manager.rb
@@ -16,6 +16,7 @@ module Wrapbox
         end
 
         def pop_ec2_instance_id
+          Wrapbox.logger.debug("Wait until a new container instance are registered in \"#{@cluster}\" cluster")
           @queue.pop
         end
 

--- a/lib/wrapbox/runner/ecs/task_waiter.rb
+++ b/lib/wrapbox/runner/ecs/task_waiter.rb
@@ -1,0 +1,108 @@
+require "timeout"
+
+require "aws-sdk-ecs"
+
+module Wrapbox
+  module Runner
+    class Ecs
+      class TaskWaiter
+        MAX_DESCRIBABLE_TASK_COUNT = 100
+
+        class WaitFailure < StandardError; end
+        class TaskStopped < WaitFailure; end
+        class TaskMissing < WaitFailure; end
+        class UnknownFailure < WaitFailure; end
+        class WaitTimeout < WaitFailure; end
+
+        def initialize(cluster:, region:, delay:)
+          @cluster = cluster
+          @region = region
+          @task_arn_to_described_result = {}
+          @mutex = Mutex.new
+          @cv = ConditionVariable.new
+          Thread.new { update_described_results(delay) }
+        end
+
+        # @return Aws::ECS::Types::Task
+        def wait_task_running(task_arn, timeout: 0)
+          Timeout.timeout(timeout) do
+            @mutex.synchronize do
+              @task_arn_to_described_result[task_arn] = nil
+              loop do
+                @cv.wait(@mutex)
+
+                result = @task_arn_to_described_result[task_arn]
+                if result[:failure]
+                  case result[:failure].reason
+                  when "MISSING"
+                    raise TaskMissing
+                  else
+                    raise UnknownFailure
+                  end
+                end
+                raise TaskStopped if result[:task].last_status == "STOPPED"
+
+                break if result[:task].last_status == "RUNNING"
+              end
+
+              @task_arn_to_described_result.delete(task_arn)[:task]
+            end
+          end
+        rescue Timeout::Error
+          raise WaitTimeout
+        end
+
+        # @return Aws::ECS::Types::Task
+        def wait_task_stopped(task_arn, timeout: 0)
+          Timeout.timeout(timeout) do
+            @mutex.synchronize do
+              @task_arn_to_described_result[task_arn] = nil
+              loop do
+                @cv.wait(@mutex)
+
+                result = @task_arn_to_described_result[task_arn]
+                raise UnknownFailure if result[:failure]
+
+                break if result[:task].last_status == "STOPPED"
+              end
+
+              @task_arn_to_described_result.delete(task_arn)[:task]
+            end
+          end
+        rescue Timeout::Error
+          raise WaitTimeout
+        end
+
+        private
+
+        def update_described_results(interval)
+          client = Aws::ECS::Client.new({ region: @region }.reject { |_, v| v.nil? })
+
+          loop do
+            @mutex.synchronize do
+              unless @task_arn_to_described_result.empty?
+                begin
+                  @task_arn_to_described_result.keys.each_slice(MAX_DESCRIBABLE_TASK_COUNT) do |task_arns|
+                    resp = client.describe_tasks(cluster: @cluster, tasks: task_arns)
+                    resp.tasks.each do |task|
+                      @task_arn_to_described_result[task.task_arn] = { task: task }
+                    end
+                    resp.failures.each do |failure|
+                      @task_arn_to_described_result[failure.arn] = { failure: failure }
+                    end
+                  end
+
+                  @cv.broadcast
+                rescue Aws::ECS::Errors::ThrottlingException
+                  Wrapbox.logger.warn("Failed to describe tasks due to Aws::ECS::Errors::ThrottlingException")
+                end
+              end
+            end
+
+            sleep interval
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/wrapbox_spec.rb
+++ b/spec/wrapbox_spec.rb
@@ -27,6 +27,17 @@ describe Wrapbox do
       Wrapbox.run_cmd(["ls ."], environments: [{name: "RAILS_ENV", value: "development"}])
     end
 
+    specify "executable on ECS overriding cluster", aws: true do
+      default_clusters = [nil, "", "default"]
+      if ENV["OVERRIDDEN_ECS_CLUSTER"].nil?
+        raise "Specify OVERRIDDEN_ECS_CLUSTER"
+      end
+      if ENV["ECS_CLUSTER"] == ENV["OVERRIDDEN_ECS_CLUSTER"] || (default_clusters.include?(ENV["ECS_CLUSTER"]) && default_clusters.include?(ENV["OVERRIDDEN_ECS_CLUSTER"]))
+        raise "Specify different values for ECS_CLUSTER and OVERRIDDEN_ECS_CLUSTER"
+      end
+      Wrapbox.run_cmd(["ls ."], environments: [{name: "RAILS_ENV", value: "development"}], cluster: ENV["OVERRIDDEN_ECS_CLUSTER"])
+    end
+
     specify "executable on ECS with launch template", aws: true do
       Wrapbox.run_cmd(["ls ."], config_name: :ecs_with_launch_template, environments: [{name: "RAILS_ENV", value: "development"}])
     end


### PR DESCRIPTION
`Runner::Ecs` calls `describe_tasks` in `wait_task_stopped` as many as its tasks, so sometimes causes `Aws::ECS::Errors::ThrottlingException`.
