### PR TITLE
Add tag_specifications option to launch_instances config

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Wrapbox.run_cmd(["ls ."], environments: [{name: "RAILS_ENV", value: "development
 | enable_ecs_managed_tags | see https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method                |
 | tags                    | tags of task definitions. see also https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#register_task_definition-instance_method |
 | propagate_tags          | specify `"TASK_DEFINITION"` if you want to propagate tags to tasks. see also https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#run_task-instance_method |
-| launch_instances        | specify `launch_template` and `instance_type` for [Aws::EC2::Client#run_instances](https://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#run_instances-instance_method). You can also specify `wait_until_instance_terminated` (default: true) |
+| launch_instances        | specify `launch_template` (required), `instance_type`, and `tag_specifications` for [Aws::EC2::Client#run_instances](https://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#run_instances-instance_method). You can also specify `wait_until_instance_terminated` (default: true) |
 
 `WRAPBOX_CMD_INDEX` environment variable is available in `run_cmd` and you can distinguish logs from each command like below:
 

--- a/lib/wrapbox/runner/ecs/instance_manager.rb
+++ b/lib/wrapbox/runner/ecs/instance_manager.rb
@@ -5,11 +5,12 @@ module Wrapbox
   module Runner
     class Ecs
       class InstanceManager
-        def initialize(cluster, region, launch_template:, instance_type: nil, wait_until_instance_terminated: true)
+        def initialize(cluster, region, launch_template:, instance_type: nil, tag_specifications: nil, wait_until_instance_terminated: true)
           @cluster = cluster
           @region = region
           @launch_template = launch_template
           @instance_type = instance_type
+          @tag_specifications = tag_specifications
           @wait_until_instance_terminated = wait_until_instance_terminated
           @queue = Queue.new
           @instance_ids = []
@@ -23,6 +24,7 @@ module Wrapbox
           preparing_instance_ids = ec2_client.run_instances(
             launch_template: @launch_template,
             instance_type: @instance_type,
+            tag_specifications: @tag_specifications,
             min_count: count,
             max_count: count
           ).instances.map(&:instance_id)

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -32,4 +32,9 @@ ecs_with_launch_template:
     launch_template:
       launch_template_id: <%= ENV["LAUNCH_TEMPLATE_ID"] %>
       version: $Latest
+    tag_specifications:
+      - resource_type: instance
+        tags:
+          - key: Purpose
+            value: wrapbox_spec
     wait_until_instance_terminated: false


### PR DESCRIPTION
This is useful for adding task information to instances and makes it easier to manage them.
For example, I want to terminate the instances a wrapbox fails to terminate when the process is killed.