### PR TITLE
Retry to run the task on request limit exceeded errors

### DIFF
--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -292,7 +292,7 @@ module Wrapbox
             @logger.warn("#{log_prefix}Failure: Rate exceeded.")
             raise LaunchFailure
           rescue Aws::ECS::Errors::InvalidParameterException => e
-            raise unless e.message.include?("com.amazonaws.services.ec2.model.AmazonEC2Exception: Request limit exceeded")
+            raise unless e.message.include?("Request limit exceeded")
             # ec2:DescribeSecurityGroups is called in ecs:RunTask if awsvpc mode is used
             # cf. https://github.com/reproio/wrapbox/issues/32
             @logger.warn("#{log_prefix}Failure: #{e.message}")


### PR DESCRIPTION
This PR resolves https://github.com/reproio/wrapbox/issues/32 again.

Although I changed the code to retry run_task on the errors by https://github.com/reproio/wrapbox/pull/33, the error message recently seemed to change.
cf. https://github.com/reproio/wrapbox/issues/32#issuecomment-651343018
