### PR TITLE
Make overridable tags and propagate_tags from Wrapbox.{run,run_cmd}

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Wrapbox.run(class_name, method_name, args,
   launch_type: "EC2", # Available only for ECS runner. The "launch_type" value in the configuration is used if it is nil.
   task_role_arn: nil, # Available only for ECS runner. The "task_role_arn" value in the configuration is used if it is nil.
   execution_role_arn: nil, # Available only for ECS runner. The "execution_role_arn" value in the configuration is used if it is nil.
+  tags: nil, # Available only for ECS runner. The "tags" value in the configuration is used if it is not given.
+  propagate_tags: nil, # Available only for ECS runner. The "propagate_tags" value in the configuration is used if it is not given.
   container_definition_overrides: {},
   environments: [],
   timeout: 3600 * 24, # Available only for ECS runner. # Available only for ECS runner.
@@ -167,6 +169,8 @@ Wrapbox.run_cmd(*cmd,
   launch_type: "EC2", # Available only for ECS runner. The "launch_type" value in the configuration is used if it is nil.
   task_role_arn: nil, # Available only for ECS runner. The "task_role_arn" value in the configuration is used if it is nil.
   execution_role_arn: nil, # Available only for ECS runner. The "execution_role_arn" value in the configuration is used if it is nil.
+  tags: nil, # Available only for ECS runner. The "tags" value in the configuration is used if it is not given.
+  propagate_tags: nil, # Available only for ECS runner. The "propagate_tags" value in the configuration is used if it is not given.
   container_definition_overrides: {},
   ignore_signal: false,
   environments: [],

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -51,7 +51,7 @@ module Wrapbox
       def self.split_overridable_options_and_parameters(options)
         opts = options.dup
         overridable_options = {}
-        %i[cluster launch_type task_role_arn execution_role_arn].each do |key|
+        %i[cluster launch_type task_role_arn execution_role_arn tags propagate_tags].each do |key|
           value = opts.delete(key)
           overridable_options[key] = value if value
         end


### PR DESCRIPTION
I want to specify tags when running ECS tasks like the following.
The tag value depends on the command.

```ruby
Wrapbox.run_cmd(
  ["sh -c 'sleep 30 && env'"],
  runner: "ecs",
  config_name: "fargate",
  launch_type: "FARGATE",
  tags: [
    { key: "xxx", value: "yyy:zzz" },
  ],
  propagate_tags: "TASK_DEFINITION",
)
```