### PR TITLE
rescue from `Seahorse::Client::NetworkingError`

### DIFF
--- a/lib/wrapbox/runner/ecs/task_waiter.rb
+++ b/lib/wrapbox/runner/ecs/task_waiter.rb
@@ -101,6 +101,8 @@ module Wrapbox
                   end
 
                   @cv.broadcast
+                rescue Seahorse::Client::NetworkingError => e
+                  Wrapbox.logger.warn("Failed to connect to ECS #{e}")
                 rescue Aws::ECS::Errors::ThrottlingException
                   Wrapbox.logger.warn("Failed to describe tasks due to Aws::ECS::Errors::ThrottlingException")
                 end


### PR DESCRIPTION
Occurred error `Seahorse::Client::NetworkingError` at wrapbox initializing.

I add rescue from this error.