### PR TITLE
unexpected hash in ruby-3.0

### DIFF
--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -117,7 +117,7 @@ module Wrapbox
         @logger = Wrapbox.logger
         if options[:log_fetcher]
           type = options[:log_fetcher][:type]
-          @log_fetcher = LogFetcher.new(type, options[:log_fetcher])
+          @log_fetcher = LogFetcher.new(type, **options[:log_fetcher])
         end
       end
 


### PR DESCRIPTION
I fixed splatting log_fetcher options in deploying ECS for  ruby-3.0 kwargs.

## logs
```
--
15:59:49 |   |   | 2021-08-16 06:59:47.505 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 I, [2021-08-16T06:59:47.505451 #1]  INFO -- : Start Workflow::CopyConversionFactsDayAsTotalAccess
15:59:49 |   |   | 2021-08-16 06:59:47.776 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 #<Thread:0x00007f2d8c64a5f8 /app/workflows/jobs/copy_from_gcs_to_s3.rb:37 run> terminated with exception (report_on_exception is true):
15:59:49 |   |   | 2021-08-16 06:59:47.776 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox/log_fetcher.rb:8:in `new': wrong number of arguments (given 2, expected 1) (ArgumentError)
15:59:49 |   |   | 2021-08-16 06:59:47.776 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox/runner/ecs.rb:120:in `initialize'
15:59:49 |   |   | 2021-08-16 06:59:47.776 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox/configuration.rb:96:in `new'
15:59:49 |   |   | 2021-08-16 06:59:47.776 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox/configuration.rb:96:in `run_cmd'
15:59:49 |   |   | 2021-08-16 06:59:47.776 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox.rb:28:in `run_cmd'
15:59:49 |   |   | 2021-08-16 06:59:47.776 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/workflows/jobs/copy_from_gcs_to_s3.rb:38:in `block (3 levels) in run'
15:59:49 |   |   | 2021-08-16 06:59:47.871 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 #<Thread:0x00007f2d8c71e920 /app/workflows/jobs/copy_from_gcs_to_s3.rb:37 run> terminated with exception (report_on_exception is true):
15:59:49 |   |   | 2021-08-16 06:59:47.871 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox/log_fetcher.rb:8:in `new': wrong number of arguments (given 2, expected 1) (ArgumentError)
15:59:49 |   |   | 2021-08-16 06:59:47.871 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox/runner/ecs.rb:120:in `initialize'
15:59:49 |   |   | 2021-08-16 06:59:47.871 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox/configuration.rb:96:in `new'
15:59:49 |   |   | 2021-08-16 06:59:47.871 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox/configuration.rb:96:in `run_cmd'
15:59:49 |   |   | 2021-08-16 06:59:47.871 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/vendor/bundle/ruby/3.0.0/bundler/gems/wrapbox-ee3c1ddbf84a/lib/wrapbox.rb:28:in `run_cmd'
15:59:49 |   |   | 2021-08-16 06:59:47.871 dev_staging/wrapbox_batch_dev_staging/7ee7af828b29422cb61cec8ddef413d0 	from /app/workflows/jobs/copy_from_gcs_to_s3.rb:38:in `block (3 levels) in run'
```
