### PR TITLE
Ignore throttling exception in Wrapbox::LogFetcher::Awslogs

### DIFF
--- a/lib/wrapbox/log_fetcher/awslogs.rb
+++ b/lib/wrapbox/log_fetcher/awslogs.rb
@@ -59,15 +59,14 @@ module Wrapbox
               @max_timestamp = ev.timestamp if @max_timestamp < ev.timestamp
             end
           end
-          Thread.start do
-            @displayed_event_ids.each do |event_id, ts|
-              if ts < (Time.now.to_f - 600) * 1000
-                @displayed_event_ids.delete(event_id)
-              end
+
+          @displayed_event_ids.each do |event_id, ts|
+            if ts < (Time.now.to_f - 600) * 1000
+              @displayed_event_ids.delete(event_id)
             end
-          end.tap do
-            sleep @delay
-          end.join
+          end
+
+          sleep @delay
         end
       end
 

--- a/lib/wrapbox/log_fetcher/awslogs.rb
+++ b/lib/wrapbox/log_fetcher/awslogs.rb
@@ -45,7 +45,6 @@ module Wrapbox
           log_group_name: @log_group,
           log_stream_names: log_stream_names,
           filter_pattern: @filter_pattern,
-          interleaved: true,
         }.compact
         @max_timestamp = ((Time.now.to_f - 120) * 1000).round
 
@@ -67,7 +66,7 @@ module Wrapbox
               end
             end
           end.tap do
-            sleep @delay 
+            sleep @delay
           end.join
         end
       end


### PR DESCRIPTION
The error is sometimes raised but doesn't affect the main feature, so we can ignore it.

Here is reproducible code:

```ruby
require 'aws-sdk-ecs'
require 'wrapbox'
require 'wrapbox/log_fetcher/awslogs'


task = Aws::ECS::Client.new.describe_tasks(tasks: [ENV.fetch('TASK_ID')]).tasks.first
fetcher = Wrapbox::LogFetcher::Awslogs.new(log_group: ENV.fetch('LOG_GROUP'), log_stream_prefix: ENV.fetch('LOG_STREAM_PREFIX'))

Array.new(1000) do |i|
  sleep i / 10000.0
  fetcher.run(task: task)
end.each(&:join)
```

```
% git rev-parse HEAD
f0c03dfffc502ce30bdb0aa1e78c41beb40c032b
% LOG_GROUP=/ecs/hello-loop-fargate TASK_ID=c0abddf2a0024c62bbf01f1dbe1a01f6 LOG_STREAM_PREFIX=ecs ruby -Ilib /path/to/script.rb >/dev/null
#<Thread:0x00007fd277de3838 /Users/arabiki/ghq/src/github.com/reproio/wrapbox/lib/wrapbox/log_fetcher/awslogs.rb:29 run> terminated with exception (report_on_exception is true):
/Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/seahorse/client/plugins/raise_response_errors.rb:17:in `call': Rate exceeded (Aws::CloudWatchLogs::Errors::ThrottlingException)
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:22:in `call'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/aws-sdk-core/plugins/idempotency_token.rb:19:in `call'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/aws-sdk-core/plugins/param_converter.rb:26:in `call'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/seahorse/client/plugins/request_callback.rb:71:in `call'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/aws-sdk-core/plugins/response_paging.rb:12:in `call'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/seahorse/client/plugins/response_target.rb:24:in `call'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/seahorse/client/request.rb:72:in `send_request'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/aws-sdk-core/pageable_response.rb:110:in `next_response'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/aws-sdk-core/pageable_response.rb:83:in `next_page'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.122.1/lib/aws-sdk-core/pageable_response.rb:95:in `each'
        from /Users/arabiki/ghq/src/github.com/reproio/wrapbox/lib/wrapbox/log_fetcher/awslogs.rb:55:in `main_loop'
        from /Users/arabiki/ghq/src/github.com/reproio/wrapbox/lib/wrapbox/log_fetcher/awslogs.rb:30:in `block in run'
-- snip --
```