### PR TITLE
Fix "validation error detected: Value '[]' at 'logStreamNames' ..."

### DIFF
--- a/lib/wrapbox/log_fetcher/awslogs.rb
+++ b/lib/wrapbox/log_fetcher/awslogs.rb
@@ -27,6 +27,14 @@ module Wrapbox
 
       def run(task:)
         @loop_thread = Thread.start do
+          # It smees that task.contaienrs is empty
+          # if capacity_provider_strategy is specified and there are no remaining capacity
+          while task.containers.empty?
+            Wrapbox.logger.warn("The task has no containers, so fetch it again")
+            sleep 10
+            task = ecs_client.describe_tasks(cluster: task.cluster_arn, tasks: [task.task_arn]).tasks.first
+          end
+
           main_loop(task)
         end
       end


### PR DESCRIPTION
It seems that task.contaienrs is empty if capacity_provider_strategy is specified and there is no remaining capacity like below, and if taskcontainers is empty, the above error occurs:

```
=> #<struct Aws::ECS::Types::Task
 -- snip --
 containers=[],
 cpu="2038",
 created_at=2022-08-15 14:20:12 1228931/4194304 +0900,
 desired_status="RUNNING",
 enable_execute_command=false,
 execution_stopped_at=nil,
  -- snip --
 last_status="PROVISIONING",
 launch_type="EC2",
 memory="3000",
  -- snip --
```

So, this PR fixes the error by fetching the task until it has containers like below:

```
W, [2022-08-15T14:41:23.325608 #66226]  WARN -- : The task has no containers, so fetch it again
W, [2022-08-15T14:41:33.375656 #66226]  WARN -- : The task has no containers, so fetch it again
-- snip --
W, [2022-08-15T14:44:54.367189 #66226]  WARN -- : The task has no containers, so fetch it again
W, [2022-08-15T14:45:04.412225 #66226]  WARN -- : The task has no containers, so fetch it again
I, [2022-08-15T14:45:17.302569 #66226]  INFO -- : #0 Launch Task: arn:aws:ecs:ap-northeast-1:<account-id>:task/<cluster>/294a3284ded0408fbb1fe8a17e1289a5
2022-08-15 14:45:14.609 <stream-prefix>/294a3284ded0408fbb1fe8a17e1289a5 ...
```