### PR TITLE
Support Ruby3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.6
           - 2.7
           - 3.0
+          - 3.1
         os:
           - ubuntu-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}

--- a/lib/wrapbox/runner/ecs.rb
+++ b/lib/wrapbox/runner/ecs.rb
@@ -81,7 +81,7 @@ module Wrapbox
         @propagate_tags = options[:propagate_tags]
         @enable_execute_command = options[:enable_execute_command]
         if options[:launch_instances]
-          @instance_manager = Wrapbox::Runner::Ecs::InstanceManager.new(@cluster, @region, options[:launch_instances])
+          @instance_manager = Wrapbox::Runner::Ecs::InstanceManager.new(@cluster, @region, **options[:launch_instances])
         end
         @task_waiter = Wrapbox::Runner::Ecs::TaskWaiter.new(cluster: @cluster, region: @region, delay: WAIT_DELAY)
 


### PR DESCRIPTION
Add double splat to Hash.

See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/