### PR TITLE
Fix yaml loading for Ruby 3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
           - 2.7
           - 3.0
           - 3.1
+          - 3.2
         os:
           - ubuntu-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}

--- a/lib/wrapbox/config_repository.rb
+++ b/lib/wrapbox/config_repository.rb
@@ -8,7 +8,12 @@ module Wrapbox
     end
 
     def load_yaml(yaml_file)
-      configs = YAML.load(ERB.new(File.read(yaml_file)).result)
+      file = ERB.new(File.read(yaml_file)).result
+      configs = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("4.0.0")
+        YAML.load(file, aliases: true)
+      else
+        YAML.load(file)
+      end
       configs.each do |name, configuration|
         load_config(name, configuration.merge("name" => name))
       end

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -1,7 +1,10 @@
-default:
+base: &base
   cluster: <%= ENV["ECS_CLUSTER"] %>
   runner: ecs
   region: ap-northeast-1
+
+default:
+  <<: *base
   container_definition:
     image: joker1007/wrapbox@sha256:0925926e867244907f7f72b322a24312501719960d10c989a3847de4890ec55a
     cpu: 256
@@ -20,9 +23,7 @@ docker:
     memory: 1024
 
 ecs_with_launch_template:
-  cluster: <%= ENV["ECS_CLUSTER"] %>
-  runner: ecs
-  region: ap-northeast-1
+  <<: *base
   container_definition:
     image: joker1007/wrapbox@sha256:0925926e867244907f7f72b322a24312501719960d10c989a3847de4890ec55a
     cpu: 256
@@ -49,9 +50,7 @@ ecs_without_runner:
     essential: true
 
 ecs_enable_execute_command:
-  cluster: <%= ENV["ECS_CLUSTER"] %>
-  runner: ecs
-  region: ap-northeast-1
+  <<: *base
   enable_execute_command: true
   container_definition:
     image: joker1007/wrapbox@sha256:0925926e867244907f7f72b322a24312501719960d10c989a3847de4890ec55a
@@ -60,9 +59,7 @@ ecs_enable_execute_command:
     essential: true
 
 ecs_disable_execute_command:
-  cluster: <%= ENV["ECS_CLUSTER"] %>
-  runner: ecs
-  region: ap-northeast-1
+  <<: *base
   enable_execute_command: false
   container_definition:
     image: joker1007/wrapbox@sha256:0925926e867244907f7f72b322a24312501719960d10c989a3847de4890ec55a
@@ -71,9 +68,7 @@ ecs_disable_execute_command:
     essential: true
 
 ecs_with_awslogs_fetcher:
-  cluster: <%= ENV["ECS_CLUSTER"] %>
-  runner: ecs
-  region: ap-northeast-1
+  <<: *base
   execution_role_arn: <%= ENV["EXECUTION_ROLE_ARN"] %>
   log_fetcher:
     type: awslogs


### PR DESCRIPTION
Psych 4 included in Ruby 3.1 complains when using aliases in yaml files.
This PR adds `aliases: true` option to load yaml as before.

ref: https://bugs.ruby-lang.org/issues/17866