### PR TITLE
Support ActiveSupport 7.1.x

### DIFF
--- a/lib/wrapbox/configuration.rb
+++ b/lib/wrapbox/configuration.rb
@@ -1,3 +1,4 @@
+require "active_support"
 require "active_support/core_ext/hash"
 require "active_support/core_ext/string"
 


### PR DESCRIPTION
I met the following error if use with ActiveSupport 7.1.x.

```console
❯ bundle exec exe/wrapbox --help
bundler: failed to load command: exe/wrapbox (exe/wrapbox)
/home/kenji/.local/share/rtx/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/core_ext/array/conversions.rb:108:in `<class:Array>': undefined method `deprecator' for ActiveSupport:Module (NoMethodError)

  deprecate to_default_s: :to_s, deprecator: ActiveSupport.deprecator
                                                          ^^^^^^^^^^^
```

I've added `require "active_support"` before load other active_support libraries to fix the issue.

See
- https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support
- https://github.com/rails/rails/issues/49495