### PR TITLE
Support retrying interrupted FARGATE task

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.7
-          - 3.0
-          - 3.1
           - 3.2
+          - 3.3
+          - 3.4
         os:
           - ubuntu-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}


### PR DESCRIPTION
Tasks executed with FARGATE_SPOT may be interrupted. When interrupted, the following log is output.

```
Task wrapbox_test is failed. task=arn:aws:ecs:xxx:xxx:task/xxx/xxx, cmd_index=60, exit_code=2, task_stopped_reason=Your Spot Task was interrupted., container_stopped_reason= (Wrapbox::Runner::Ecs::ExecutionFailure)
```

Handling this log, the Spot Task is retried in the wrapbox. This